### PR TITLE
Add macOS installer script and installation guide

### DIFF
--- a/PlumoAI-Installer.command
+++ b/PlumoAI-Installer.command
@@ -1,0 +1,124 @@
+#!/bin/bash
+# PlumoAI Installer for macOS - double-clickable bootstrapper.
+#
+# This is the macOS counterpart to PlumoAISetup.exe on Windows: a Mac user
+# downloads this one file, double-clicks it, and it installs PlumoAI.
+#
+# It fetches the PlumoAI repository (or uses a checkout it is sitting inside),
+# then hands off to install-macos.sh, which checks prerequisites, installs
+# Docker Desktop if needed, and starts the stack.
+#
+# Written for the bash 3.2 that ships with macOS.
+
+# Keep the Terminal window open on exit so double-click users see the result.
+trap 'printf "\n  Press Return to close this window."; read -r _' EXIT
+
+REPO_URL="https://github.com/PlumoAI/plumoai.git"
+# Where to clone when this file is run on its own (override for testing).
+INSTALL_DIR="${PLUMOAI_INSTALL_DIR:-$HOME/PlumoAI}"
+
+# ---------- output ----------
+if [ -t 1 ]; then
+  DIM='\033[0;90m'; RED='\033[0;31m'; GRN='\033[0;32m'
+  MAG='\033[0;35m'; CYN='\033[0;96m'; OFF='\033[0m'
+else
+  DIM=''; RED=''; GRN=''; MAG=''; CYN=''; OFF=''
+fi
+
+printf "\n  %sPlumo%sAi%s\n" "$MAG" "$CYN" "$OFF"
+printf "  %sInstaller for macOS%s\n\n" "$DIM" "$OFF"
+
+die() {
+  printf "\n  %s%s%s\n" "$RED" "$1" "$OFF" >&2
+  [ -n "$2" ] && printf "        %s\n" "$2" >&2
+  exit 1
+}
+
+# ---------- locate install-macos.sh ----------
+# Case 1: this .command was distributed inside a repo checkout, next to the
+# installer script. Use that checkout directly.
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -f "$SELF_DIR/install-macos.sh" ] && [ -f "$SELF_DIR/install.sh" ]; then
+  REPO_DIR="$SELF_DIR"
+  printf "  %s..%s    Using installer next to this file: %s\n" "$DIM" "$OFF" "$REPO_DIR"
+else
+  # Case 2: standalone download. We need git to fetch the repo.
+  if ! command -v git >/dev/null 2>&1; then
+    printf "  %s..%s    Git is required and was not found. Requesting the Command Line Tools...\n" "$DIM" "$OFF"
+    xcode-select --install 2>/dev/null || true
+    die "Git (Xcode Command Line Tools) needs to be installed first." \
+        "A system dialog should have opened. Finish that install, then double-click this file again."
+  fi
+
+  if [ -d "$INSTALL_DIR/.git" ]; then
+    printf "  %s..%s    Updating existing PlumoAI at %s ...\n" "$DIM" "$OFF" "$INSTALL_DIR"
+    git -C "$INSTALL_DIR" pull --ff-only 2>/dev/null || \
+      printf "  %swarn%s  could not fast-forward; using the existing copy as-is\n" "$RED" "$OFF"
+  else
+    printf "  %s..%s    Downloading PlumoAI into %s ...\n" "$DIM" "$OFF" "$INSTALL_DIR"
+    git clone "$REPO_URL" "$INSTALL_DIR" || \
+      die "Download failed." "Check your internet connection and try again."
+  fi
+  REPO_DIR="$INSTALL_DIR"
+fi
+
+# ---------- hand off ----------
+cd "$REPO_DIR" || die "Could not enter $REPO_DIR."
+
+# Runs a command, or just prints it when PLUMOAI_DRY_RUN is set (used by tests).
+run_or_echo() {
+  if [ -n "${PLUMOAI_DRY_RUN:-}" ]; then
+    printf "  %s[dry-run]%s would run: %s\n" "$DIM" "$OFF" "$*"
+    return 0
+  fi
+  "$@"
+}
+
+printf "  %sok%s    Ready. Starting the installer...\n\n" "$GRN" "$OFF"
+printf "  %s----------------------------------------------------------%s\n\n" "$DIM" "$OFF"
+
+if [ -f install-macos.sh ]; then
+  # Preferred path: the full macOS installer (checks prerequisites, installs
+  # Docker Desktop if needed, then runs install.sh).
+  chmod +x install-macos.sh 2>/dev/null || true
+  run_or_echo ./install-macos.sh "$@"
+  status=$?
+else
+  # Fallback: this version of the repo predates install-macos.sh (e.g. it has
+  # not been merged yet). Run install.sh directly, after making sure Docker is
+  # up ourselves, since install.sh does not install Docker.
+  printf "  %s..%s    install-macos.sh not present in this version; using install.sh directly.\n" "$DIM" "$OFF"
+
+  if ! docker info >/dev/null 2>&1; then
+    if [ -d /Applications/Docker.app ]; then
+      printf "  %s..%s    Starting Docker Desktop...\n" "$DIM" "$OFF"
+      open -a Docker 2>/dev/null || true
+      w=0
+      while [ "$w" -lt 120 ]; do
+        docker info >/dev/null 2>&1 && break
+        sleep 3; w=$((w + 3))
+      done
+    fi
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    die "Docker Desktop is required and is not running." \
+        "Install it from https://www.docker.com/products/docker-desktop/ then double-click this file again."
+  fi
+
+  [ -f install.sh ] || die "install.sh is missing from the download." "The repository may be incomplete; try again."
+  chmod +x install.sh 2>/dev/null || true
+  run_or_echo ./install.sh "$@"
+  status=$?
+fi
+
+printf "\n  %s----------------------------------------------------------%s\n" "$DIM" "$OFF"
+if [ "$status" -eq 0 ]; then
+  printf "  %sDone.%s PlumoAI is installed in %s\n" "$GRN" "$OFF" "$REPO_DIR"
+else
+  printf "  %sThe installer exited with an error (code %s).%s\n" "$RED" "$status" "$OFF"
+  printf "        The output above shows what happened.\n"
+fi
+
+exit "$status"

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -1,0 +1,200 @@
+# Install PlumoAI on macOS
+
+PlumoAI runs on macOS as a Docker Compose stack, the same containers used on Linux and Windows.
+There is no separate macOS build and no feature difference between platforms.
+
+Three ways to install:
+
+- **[Double-click installer](#double-click-installer)** - download one file, double-click it. Closest to the Windows `PlumoAISetup.exe` experience.
+- **[Quick install](#quick-install)** - one script that checks prerequisites, installs Docker Desktop if needed, and starts the stack.
+- **[Manual install](#manual-install)** - the same steps run by hand.
+
+---
+
+## Requirements
+
+| | |
+|---|---|
+| macOS | 12 (Monterey) or newer |
+| Chip | Apple Silicon or Intel |
+| Docker | Docker Desktop with Compose v2 |
+| Git | Included with the Xcode Command Line Tools |
+| Disk | About 6 GB for images and volumes |
+
+For **domain mode** you also need an `A`/`AAAA` record pointing at the host and inbound ports **80** and **443** open.
+
+---
+
+## Double-click installer
+
+For users who would rather not touch the command line, `PlumoAI-Installer.command` is a double-clickable bootstrapper - the macOS counterpart to `PlumoAISetup.exe` on Windows.
+
+1. Download `PlumoAI-Installer.command` (or the `.zip` containing it, then unzip).
+2. **Right-click it and choose Open** the first time, then confirm. macOS shows a warning for any downloaded, unsigned file; right-click-Open is how you approve it. A plain double-click works on every launch after that.
+3. A Terminal window opens and the install runs. When it finishes, your browser opens at the running instance.
+
+Behind the scenes it downloads PlumoAI into `~/PlumoAI` (or uses a checkout it is sitting inside), then runs `install-macos.sh`. If that script is not present in the version it fetches, it falls back to running `install.sh` directly.
+
+> The one-time warning is expected. Removing it entirely requires an Apple Developer ID to sign and notarize the file, the same way the Windows installer would need a code-signing certificate to avoid SmartScreen.
+
+## Quick install
+
+```bash
+git clone https://github.com/PlumoAI/plumoai.git
+cd plumoai
+chmod +x install-macos.sh
+./install-macos.sh
+```
+
+The script will:
+
+1. Verify the macOS version and that Git is available.
+2. Check for Docker Desktop, and offer to install it through Homebrew if it is missing.
+3. Start Docker Desktop and wait for the daemon to come up.
+4. Confirm Docker Compose v2 is present.
+5. Hand off to `install.sh`, which creates `.env`, generates secrets, and starts the containers.
+6. Open your browser at the running instance.
+
+### Check without changing anything
+
+To see what the installer would do on this machine without installing or starting anything:
+
+```bash
+./install-macos.sh --check
+```
+
+Example output:
+
+```
+  PlumoAi
+  Self-Hosted - macOS installer
+
+  check mode - nothing will be installed or changed
+
+Checking prerequisites
+  ok    macOS 15.2 (arm64)
+  ok    git 2.50.1
+  ok    Homebrew 4.4.0
+  ok    Docker Desktop found
+  ok    Docker daemon is running
+  ok    Docker Compose v2 (2.31.0)
+
+Repository
+  ok    Using existing checkout: /Users/you/plumoai
+
+  This Mac is ready. Run ./install-macos.sh to install.
+```
+
+### Options
+
+| Flag | Effect |
+|---|---|
+| `--check` | Report prerequisites only. Installs nothing, starts nothing. |
+| `--fresh` | Passed through to `install.sh`: backs up, then resets the MySQL volume. |
+| `--no-backup` | Passed through to `install.sh`: skip the backup that `--fresh` takes first. |
+| `--no-open` | Do not open the browser when the install finishes. |
+| `--help` | Show usage. |
+
+---
+
+## Manual install
+
+If you would rather not use the wrapper, or Docker Desktop is already set up:
+
+### 1. Install Docker Desktop
+
+```bash
+brew install --cask docker
+open -a Docker
+```
+
+Or download it from [docker.com](https://www.docker.com/products/docker-desktop/). Wait for the whale icon in the menu bar to stop animating, then confirm:
+
+```bash
+docker compose version
+```
+
+### 2. Clone
+
+```bash
+git clone https://github.com/PlumoAI/plumoai.git
+cd plumoai
+```
+
+### 3. Optional: configure `.env`
+
+You can skip this. Step 4 creates `.env` from `.env.example` and prompts for the values it needs when run interactively. For production or non-interactive installs, write it in advance.
+
+**Domain mode (recommended for production):**
+
+```ini
+RUN_MODE=domain
+DOMAIN_NAME=self.example.com
+SSL_EMAIL=admin@example.com
+```
+
+**Localhost mode (HTTP):**
+
+```ini
+RUN_MODE=localhost
+LOCALHOST_PORT=7861
+```
+
+### 4. Install and start
+
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+First run pulls images and initialises the databases, which usually takes 5 to 10 minutes.
+
+When it finishes, PlumoAI is at `http://localhost:7861` in localhost mode, or `https://your-domain` in domain mode.
+
+---
+
+## Managing the stack
+
+```bash
+docker compose ps                       # container status
+docker compose logs --tail 200 -f       # follow logs
+docker compose stop                     # stop, keep data
+docker compose start                    # start again
+docker compose down                     # stop and remove containers, keep volumes
+```
+
+Reset the database and start over, taking a backup first:
+
+```bash
+./install.sh --fresh
+```
+
+---
+
+## Troubleshooting
+
+**`Cannot connect to the Docker daemon`**
+Docker Desktop is installed but not running. Start it with `open -a Docker` and wait for the menu bar icon to settle, then re-run.
+
+**`Docker Compose not found`**
+Docker Desktop bundles Compose v2. If `docker compose version` fails, update Docker Desktop to a current release.
+
+**Port 7861 already in use**
+Something else holds the port. Find it with `lsof -i :7861`, then either stop that process or set a different `LOCALHOST_PORT` in `.env`.
+
+**Docker Desktop asks for a password on first launch**
+Expected. It installs a privileged helper the first time it runs. Complete that prompt before re-running the installer.
+
+**Apple Silicon image warnings**
+Some images may pull an `amd64` build and run under Rosetta emulation. It works, but it is slower. Nothing needs changing.
+
+**Installer says macOS is not supported**
+The script requires macOS 12 or newer, because that is Docker Desktop's own minimum. Check with `sw_vers -productVersion`.
+
+---
+
+## Related
+
+- [Linux install](install-linux.md)
+- [Windows install](install-windows.md)
+- [Architecture](architecture.md)

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+# PlumoAI Self-Hosted - macOS installer
+# Prepares a Mac for PlumoAI, then hands off to install.sh (the cross-platform installer).
+# Keep behavior aligned with install.ps1 (Windows) and install.sh (Linux / macOS / WSL).
+#
+# Usage:
+#   ./install-macos.sh              # check prerequisites, then install and start
+#   ./install-macos.sh --check      # check prerequisites only, change nothing
+#   ./install-macos.sh --fresh      # pass --fresh through to install.sh
+#   ./install-macos.sh --no-open    # do not open the browser at the end
+#
+# Written for the bash 3.2 that ships with macOS, so it avoids bash 4+ syntax
+# and GNU-only flags (sed -i, readlink -f, base64 -w).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REPO_URL="https://github.com/PlumoAI/plumoai.git"
+MIN_MACOS_MAJOR=12          # Docker Desktop requires macOS 12 (Monterey) or newer
+DOCKER_APP="/Applications/Docker.app"
+
+CHECK_ONLY=false
+OPEN_BROWSER=true
+PASSTHRU=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --check)      CHECK_ONLY=true ;;
+    --no-open)    OPEN_BROWSER=false ;;
+    --fresh)      PASSTHRU="$PASSTHRU --fresh" ;;
+    --no-backup)  PASSTHRU="$PASSTHRU --no-backup" ;;
+    -h|--help)
+      awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+      exit 0 ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      echo "Run './install-macos.sh --help' for usage." >&2
+      exit 1 ;;
+  esac
+done
+
+# ---------- output helpers ----------
+
+if [ -t 1 ]; then
+  C_DIM='\033[0;90m'; C_RED='\033[0;31m'; C_GREEN='\033[0;32m'
+  C_YELLOW='\033[0;33m'; C_MAGENTA='\033[0;35m'; C_CYAN='\033[0;96m'; C_OFF='\033[0m'
+else
+  C_DIM=''; C_RED=''; C_GREEN=''; C_YELLOW=''; C_MAGENTA=''; C_CYAN=''; C_OFF=''
+fi
+
+ok()   { printf "  %sok%s    %s\n"   "$C_GREEN"  "$C_OFF" "$1"; }
+info() { printf "  %s..%s    %s\n"   "$C_DIM"    "$C_OFF" "$1"; }
+warn() { printf "  %swarn%s  %s\n"   "$C_YELLOW" "$C_OFF" "$1"; }
+fail() { printf "  %sfail%s  %s\n"   "$C_RED"    "$C_OFF" "$1" >&2; }
+
+banner() {
+  echo ""
+  printf "  %sPlumo%sAi%s\n" "$C_MAGENTA" "$C_CYAN" "$C_OFF"
+  printf "  %sSelf-Hosted - macOS installer%s\n" "$C_DIM" "$C_OFF"
+  echo ""
+}
+
+die() {
+  echo ""
+  fail "$1"
+  [ -n "$2" ] && printf "        %s\n" "$2" >&2
+  echo ""
+  exit 1
+}
+
+# ---------- spinner ----------
+# Braille frames for the animated wait indicator.
+SPIN_FRAMES=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
+
+# spin_wait <timeout_secs> <message> <check-cmd...>
+# Animates a spinner while polling <check-cmd> until it succeeds, or times out.
+# Returns 0 on success, 1 on timeout. Leaves no residual line: the caller prints
+# the result. Falls back to plain dots when stdout is not a terminal (e.g. a log).
+spin_wait() {
+  local timeout="$1" msg="$2"; shift 2
+  local i=0 secs=0 n="${#SPIN_FRAMES[@]}"
+
+  if [ ! -t 1 ]; then
+    printf "  %s..%s    %s" "$C_DIM" "$C_OFF" "$msg"
+    while [ "$secs" -lt "$timeout" ]; do
+      "$@" >/dev/null 2>&1 && { printf "\n"; return 0; }
+      printf "."; sleep 2; secs=$((secs + 2))
+    done
+    printf "\n"; return 1
+  fi
+
+  printf '\033[?25l'  # hide cursor
+  while [ "$secs" -lt "$timeout" ]; do
+    # Poll roughly once a second (every 8 frames at ~0.12s each).
+    if [ $((i % 8)) -eq 0 ] && "$@" >/dev/null 2>&1; then
+      printf '\r\033[K\033[?25h'   # clear line, restore cursor
+      return 0
+    fi
+    printf '\r  %s%s%s    %s' "$C_CYAN" "${SPIN_FRAMES[$((i % n))]}" "$C_OFF" "$msg"
+    sleep 0.12
+    i=$((i + 1))
+    secs=$((i * 12 / 100))
+  done
+  printf '\r\033[K\033[?25h'       # clear line, restore cursor
+  return 1
+}
+
+# ---------- checks ----------
+
+check_macos() {
+  if [ "$(uname -s)" != "Darwin" ]; then
+    die "This installer is for macOS." "On Linux or WSL use ./install.sh, on Windows use install.ps1."
+  fi
+
+  local ver major
+  ver="$(sw_vers -productVersion 2>/dev/null || echo "0")"
+  major="$(echo "$ver" | cut -d. -f1)"
+
+  if [ "$major" -lt "$MIN_MACOS_MAJOR" ] 2>/dev/null; then
+    die "macOS $ver is not supported." \
+        "Docker Desktop needs macOS $MIN_MACOS_MAJOR (Monterey) or newer."
+  fi
+  ok "macOS $ver ($(uname -m))"
+}
+
+check_homebrew() {
+  if command -v brew >/dev/null 2>&1; then
+    ok "Homebrew $(brew --version 2>/dev/null | head -1 | awk '{print $2}')"
+    return 0
+  fi
+  warn "Homebrew not found (only needed to auto-install Docker Desktop)"
+  return 1
+}
+
+check_git() {
+  if ! command -v git >/dev/null 2>&1; then
+    die "Git not found." \
+        "Install the Command Line Tools with:  xcode-select --install"
+  fi
+  ok "git $(git --version | awk '{print $3}')"
+}
+
+docker_installed() {
+  command -v docker >/dev/null 2>&1 || [ -d "$DOCKER_APP" ]
+}
+
+docker_running() {
+  docker info >/dev/null 2>&1
+}
+
+install_docker() {
+  echo ""
+  info "Docker Desktop is required and was not found."
+
+  if [ "$CHECK_ONLY" = true ]; then
+    warn "check mode: would install Docker Desktop via Homebrew"
+    return 1
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    die "Cannot install Docker Desktop automatically without Homebrew." \
+        "Install Docker Desktop from https://www.docker.com/products/docker-desktop/ then re-run."
+  fi
+
+  printf "  Install Docker Desktop now via Homebrew? [y/N] "
+  read -r reply
+  case "$reply" in
+    [yY]|[yY][eE][sS]) ;;
+    *) die "Docker Desktop is required to continue." \
+           "Install it from https://www.docker.com/products/docker-desktop/ then re-run." ;;
+  esac
+
+  info "Installing Docker Desktop (this can take a few minutes)..."
+  if ! brew install --cask docker; then
+    die "Homebrew failed to install Docker Desktop." \
+        "Install it manually from https://www.docker.com/products/docker-desktop/"
+  fi
+  ok "Docker Desktop installed"
+}
+
+start_docker() {
+  if [ "$CHECK_ONLY" = true ]; then
+    warn "check mode: would start Docker Desktop and wait for the daemon"
+    return 1
+  fi
+
+  info "Starting Docker Desktop..."
+  open -a Docker 2>/dev/null || die "Could not launch Docker Desktop." "Open it from Applications, then re-run."
+
+  if spin_wait 120 "Waiting for the Docker daemon" docker info; then
+    ok "Docker daemon is running"
+    return 0
+  fi
+
+  die "Docker did not become ready within 120 seconds." \
+      "Open Docker Desktop, finish any first-run setup, then re-run this script."
+}
+
+check_docker() {
+  if ! docker_installed; then
+    install_docker || return 1
+  else
+    ok "Docker Desktop found"
+  fi
+
+  if ! docker_running; then
+    warn "Docker daemon is not running"
+    start_docker || return 1
+  else
+    ok "Docker daemon is running"
+  fi
+
+  # install.sh needs one of these; check the same way it does
+  if docker compose version >/dev/null 2>&1; then
+    ok "Docker Compose v2 ($(docker compose version --short 2>/dev/null))"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    ok "docker-compose (legacy) found"
+  else
+    die "Docker Compose not found." \
+        "Docker Desktop normally bundles Compose v2. Update Docker Desktop and re-run."
+  fi
+}
+
+# ---------- repo ----------
+
+resolve_repo() {
+  # Already inside a checkout (install.sh sits next to this script)
+  if [ -f "$SCRIPT_DIR/install.sh" ] && [ -f "$SCRIPT_DIR/docker-compose.yml" ]; then
+    REPO_DIR="$SCRIPT_DIR"
+    ok "Using existing checkout: $REPO_DIR"
+    return 0
+  fi
+
+  REPO_DIR="$PWD/plumoai"
+
+  if [ -d "$REPO_DIR/.git" ]; then
+    ok "Found existing clone: $REPO_DIR"
+    return 0
+  fi
+
+  if [ "$CHECK_ONLY" = true ]; then
+    warn "check mode: would clone $REPO_URL into $REPO_DIR"
+    return 1
+  fi
+
+  info "Cloning PlumoAI into $REPO_DIR ..."
+  git clone "$REPO_URL" "$REPO_DIR" || die "git clone failed." "Check your network connection and try again."
+  ok "Cloned"
+}
+
+# ---------- run ----------
+
+run_installer() {
+  cd "$REPO_DIR"
+
+  if [ ! -f install.sh ]; then
+    die "install.sh not found in $REPO_DIR." "The checkout looks incomplete."
+  fi
+
+  chmod +x install.sh
+  echo ""
+  info "Handing off to install.sh ..."
+  echo ""
+
+  # shellcheck disable=SC2086
+  ./install.sh $PASSTHRU
+}
+
+app_url() {
+  # Read the URL install.sh would report, from the .env it created
+  local run_mode port domain
+  [ -f "$REPO_DIR/.env" ] || return 1
+
+  run_mode="$(grep -E '^RUN_MODE=' "$REPO_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r')"
+  port="$(grep -E '^LOCALHOST_PORT=' "$REPO_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r')"
+  domain="$(grep -E '^DOMAIN_NAME=' "$REPO_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r')"
+
+  if [ "$run_mode" = "domain" ] && [ -n "$domain" ]; then
+    echo "https://$domain"
+  else
+    echo "http://localhost:${port:-7861}"
+  fi
+}
+
+# ---------- main ----------
+
+banner
+
+if [ "$CHECK_ONLY" = true ]; then
+  printf "  %scheck mode - nothing will be installed or changed%s\n\n" "$C_DIM" "$C_OFF"
+fi
+
+echo "Checking prerequisites"
+check_macos
+check_git
+check_homebrew || true
+check_docker || CHECK_INCOMPLETE=true
+
+echo ""
+echo "Repository"
+resolve_repo || CHECK_INCOMPLETE=true
+
+if [ "$CHECK_ONLY" = true ]; then
+  echo ""
+  if [ "${CHECK_INCOMPLETE:-false}" = true ]; then
+    printf "  %sSome steps would run on a real install (shown above).%s\n" "$C_YELLOW" "$C_OFF"
+  else
+    printf "  %sThis Mac is ready. Run ./install-macos.sh to install.%s\n" "$C_GREEN" "$C_OFF"
+  fi
+  echo ""
+  exit 0
+fi
+
+run_installer
+
+URL="$(app_url || true)"
+if [ -n "$URL" ]; then
+  echo ""
+  ok "PlumoAI is running at $URL"
+  if [ "$OPEN_BROWSER" = true ]; then
+    info "Opening $URL ..."
+    open "$URL" 2>/dev/null || true
+  fi
+fi
+echo ""


### PR DESCRIPTION
## What this does

PlumoAI already runs on macOS through `install.sh`, but there is no macOS entry point equivalent to `install.ps1` on Windows, and `docs/` has no macOS page. This adds both.

### Two files

**`PlumoAI-Installer.command`** - a double-clickable bootstrapper, the macOS counterpart to `PlumoAISetup.exe`. A user downloads it, double-clicks (right-click - Open the first time to clear the Gatekeeper warning), and PlumoAI installs with no command line. It uses an adjacent checkout when shipped inside the repo, otherwise git-clones into `~/PlumoAI`, then runs `install-macos.sh` - falling back to `install.sh` directly if `install-macos.sh` is not present in the fetched version, so it works even before this PR merges.

**`install-macos.sh`** is a thin wrapper (below) that prepares a Mac and then hands off to `install.sh`, rather than duplicating any of its logic:

- Verifies macOS 12+ (Docker Desktop's own minimum) and that git is available
- Detects Docker Desktop, and offers to install it via Homebrew when missing
- Launches Docker Desktop and waits for the daemon, with a timeout and a clear message if it never comes up
- Confirms Docker Compose v2 using the same check `install.sh` uses
- Resolves the repo, cloning only when not already inside a checkout
- Passes `--fresh` and `--no-backup` straight through to `install.sh`
- Reads the resulting URL from the generated env file and opens it in the browser

There is also a `--check` flag that reports what would happen without installing or starting anything, so it is safe to run before committing to an install:

```
  PlumoAi
  Self-Hosted - macOS installer

  check mode - nothing will be installed or changed

Checking prerequisites
  ok    macOS 26.6.2 (arm64)
  ok    git 2.50.1
  ok    Homebrew 6.0.22

  ..    Docker Desktop is required and was not found.
  warn  check mode: would install Docker Desktop via Homebrew

Repository
  ok    Using existing checkout: /Users/you/plumoai
```

## Portability

Written against the bash 3.2 that ships with macOS, so it avoids bash 4+ syntax (`declare -A`, `mapfile`, parameter-case expansion) and GNU-only flags (`sed -i`, `readlink -f`, `base64 -w`). It runs on a stock system with nothing installed beyond the Xcode Command Line Tools.

## Testing

Verified on macOS 26.6.2 (arm64):

| Check | Result |
|---|---|
| Parses under `/bin/bash` 3.2 | pass |
| `shellcheck` | clean, no warnings |
| `--check` on a machine without Docker | correctly detects and declines to act |
| `--help` | pass |
| Unknown flag | rejected, exit 1 |
| GNU-only flags | none present |

The URL parsing was exercised separately across six cases: localhost with default port, localhost with a custom port, domain mode, quoted values, missing port (falls back to 7861), and domain mode with an empty domain (falls back to localhost). All six resolve correctly.

**Verified end to end on macOS 26.6.2 (arm64).** Docker Desktop 4.90.0 was installed fresh, then `./install-macos.sh` was run start to finish:

```
ok    macOS 26.6.2 (arm64)
ok    git 2.50.1
ok    Homebrew 6.0.22
ok    Docker Desktop found
ok    Docker daemon is running
ok    Docker Compose v2 (5.5.1)
ok    Using existing checkout
..    Handing off to install.sh ...
```

All 8 images pulled, all 8 containers started:

| Container | Status |
|---|---|
| ai-service | Up (healthy) |
| auth-service | Up (healthy) |
| main-app | Up (healthy) |
| plumoai-api | Up (healthy) |
| plumoai-mongodb | Up (healthy) |
| plumoai-mysql | Up (healthy) |
| traefik | Up |
| docker-socket-proxy | Up |

`http://localhost:7861` returns **HTTP 200** and serves the login page.

## Two things found while testing

**`install.sh` is not executable in the repo** (`100644`), so the README's `./install.sh` fails with `Permission denied` until you `chmod +x`. This wrapper does it automatically, but the repo file itself is worth fixing.

**`.env.example` ships with `RUN_MODE=domain`**, so any non-interactive run stops at `Error: For domain mode, DOMAIN_NAME and SSL_EMAIL must be set in .env`. `localhost` would be a safer default for a first run.

## Docs

`docs/install-macos.md` covers the quick install, the manual equivalent, the flag reference, stack management commands, and troubleshooting for the failure modes specific to macOS (daemon not running, port conflicts, the first-launch privileged helper prompt, Rosetta image warnings).

Note that `docs/install-linux.md` and `docs/install-windows.md` are currently empty placeholder files. This PR does not touch them, but they are a visible gap if anyone follows the links.


