### PR TITLE
Add CI: shellcheck, Python syntax, manifest and compose validation

### DIFF
--- a/.github/scripts/validate_compose.py
+++ b/.github/scripts/validate_compose.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Validate that the docker-compose files are structurally well-formed YAML.
+
+Docker Compose supports the custom YAML tags `!override` and `!reset` for merge
+control, which a plain safe-loader rejects. This loader tolerates unknown tags
+so the check validates structure without a false positive on valid compose.
+
+This is a syntax/structure check, not a full `docker compose config` (which would
+require a populated .env). It catches broken indentation, duplicate keys, and
+malformed YAML before a PR merges.
+
+Run from the repository root:  python3 .github/scripts/validate_compose.py
+"""
+from __future__ import annotations
+
+import sys
+from glob import glob
+
+import yaml
+
+
+class ComposeLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates Compose's !override / !reset tags."""
+
+
+def _ignore_unknown(loader, tag_suffix, node):  # noqa: ARG001
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_scalar(node)
+
+
+ComposeLoader.add_multi_constructor("!", _ignore_unknown)
+
+
+def main() -> int:
+    files = sorted(glob("docker-compose*.yml"))
+    if not files:
+        print("::error::no docker-compose*.yml files found")
+        return 1
+
+    errors = 0
+    for path in files:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                yaml.load(fh, Loader=ComposeLoader)
+            print(f"  ok    {path}")
+        except yaml.YAMLError as exc:
+            errors += 1
+            print(f"::error file={path}::invalid YAML: {exc}")
+            print(f"  ERROR {path}: {exc}")
+
+    print(f"\n{len(files)} compose file(s) checked: {errors} error(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/validate_plugins.py
+++ b/.github/scripts/validate_plugins.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate agent plugin.json and service-provider provider.json manifests.
+
+Errors (fail CI):
+  - a manifest is not valid JSON
+  - an agent plugin is missing plugin_id, type, or display_name
+  - a service provider is missing provider_code (or code) or display_name
+
+Warnings (do not fail CI, surfaced as GitHub annotations):
+  - an agent plugin has no entrypoint, or its entrypoint file is missing
+  - plugin_id does not match its directory name
+
+Run from the repository root:  python3 .github/scripts/validate_plugins.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from glob import glob
+
+errors = 0
+warnings = 0
+
+
+def err(path: str, msg: str) -> None:
+    global errors
+    errors += 1
+    print(f"::error file={path}::{msg}")
+    print(f"  ERROR  {path}: {msg}")
+
+
+def warn(path: str, msg: str) -> None:
+    global warnings
+    warnings += 1
+    print(f"::warning file={path}::{msg}")
+    print(f"  warn   {path}: {msg}")
+
+
+def load(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        err(path, f"invalid JSON: {exc}")
+    except OSError as exc:
+        err(path, f"cannot read: {exc}")
+    return None
+
+
+def check_agent(path: str) -> None:
+    data = load(path)
+    if data is None:
+        return
+    directory = os.path.dirname(path)
+    dir_name = os.path.basename(directory)
+
+    for field in ("plugin_id", "type", "display_name"):
+        if not data.get(field):
+            err(path, f"missing required field: {field}")
+
+    plugin_id = data.get("plugin_id")
+    if plugin_id and plugin_id != dir_name:
+        warn(path, f"plugin_id '{plugin_id}' does not match directory '{dir_name}'")
+
+    entrypoint = data.get("entrypoint")
+    if not entrypoint:
+        warn(path, "no entrypoint declared")
+    elif not os.path.isfile(os.path.join(directory, entrypoint)):
+        warn(path, f"entrypoint file not found: {entrypoint}")
+
+
+def check_provider(path: str) -> None:
+    data = load(path)
+    if data is None:
+        return
+    for field in ("code", "name", "auth_type"):
+        if not data.get(field):
+            err(path, f"missing required field: {field}")
+
+
+def main() -> int:
+    agents = sorted(glob("ai-agents/*/plugin.json"))
+    providers = sorted(glob("service-providers/*/provider.json"))
+
+    print(f"Validating {len(agents)} agent plugins and {len(providers)} service providers\n")
+
+    for path in agents:
+        check_agent(path)
+    for path in providers:
+        check_provider(path)
+
+    print(f"\n{len(agents) + len(providers)} manifests checked: "
+          f"{errors} error(s), {warnings} warning(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+# Lightweight checks that run on every pull request and on pushes to main.
+# All jobs are green on the current tree; each guards against a class of
+# breakage that is currently caught only by manual review, if at all.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell:
+    name: Shell scripts (shellcheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck (*.sh, *.command)
+        run: |
+          # shellcheck is pre-installed on ubuntu-latest runners.
+          # git ls-files reliably finds tracked scripts at any depth, including
+          # the repo root, without depending on globstar behaviour.
+          mapfile -t files < <(git ls-files '*.sh' '*.command')
+          if [ ${#files[@]} -eq 0 ]; then echo "no shell scripts found"; exit 0; fi
+          printf 'checking:\n%s\n' "${files[*]}"
+          # -S error matches the current tree (it is clean at this severity).
+          # Tighten to warning once the existing style warnings are addressed.
+          shellcheck -S error "${files[@]}"
+
+  python:
+    name: Python (syntax + lint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Syntax check (py_compile) — blocking
+        run: |
+          mapfile -t pyfiles < <(git ls-files '*.py')
+          echo "compiling ${#pyfiles[@]} Python files"
+          python -m py_compile "${pyfiles[@]}"
+      - name: Lint (ruff) — informational
+        continue-on-error: true
+        run: |
+          pip install --quiet ruff
+          ruff check . || true
+
+  manifests:
+    name: Plugin & provider manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate plugin.json / provider.json
+        run: python3 .github/scripts/validate_plugins.py
+
+  compose:
+    name: docker-compose files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate compose YAML
+        run: |
+          pip install --quiet pyyaml
+          python3 .github/scripts/validate_compose.py


### PR DESCRIPTION
## What this does

The repository has no continuous integration. Every PR (including the agent integrations already open) is checked only by manual review, if at all. This adds a lightweight GitHub Actions workflow that runs on each pull request and on pushes to `main`.

Four jobs, each verified green against the current tree:

| Job | Checks | Guards against |
|---|---|---|
| **shell** | `shellcheck -S error` over every tracked `*.sh` / `*.command` | broken installer / entrypoint scripts |
| **python** | `py_compile` over all tracked `*.py` (blocking) + `ruff` (informational) | an agent or node that will not import |
| **manifests** | every `ai-agents/*/plugin.json` and `service-providers/*/provider.json` parses and has its required fields | malformed plugins landing unnoticed |
| **compose** | `docker-compose*.yml` is well-formed YAML, tolerating Compose's `!override` / `!reset` tags | a broken compose file |

## Verified locally against the current tree

- `shellcheck -S error`: 6 scripts, **0 errors**
- `py_compile`: **137** Python files, **0 syntax errors**
- manifest validator: 47 manifests, **0 errors**, 2 warnings (below)
- compose validator: 3 files, **0 errors**

So the workflow is green on merge, not red-on-arrival.

## Two existing issues surfaced (as warnings, non-blocking)

The manifest validator flags these without failing CI, so they are visible but do not block:

- `ai-agents/upwork/plugin.json` declares **no `entrypoint`**
- `ai-agents/apollo.io/plugin.json` has `plugin_id: "apollo"` — **directory/id mismatch**

## Notes

- `shellcheck` runs at `-S error` because the existing scripts are clean at that severity but carry style-level warnings (49 at default). The threshold can be tightened to `warning` once those are cleaned up.
- `ruff` is informational (`continue-on-error`) so existing style does not block, while still surfacing suggestions.
- The validators live in `.github/scripts/` and can be run locally: `python3 .github/scripts/validate_plugins.py`.

This is intentionally a fast, dependency-light first layer. A natural next step is a stack smoke-test (`docker compose up`, assert the app answers) — that would catch runtime regressions the static checks cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
